### PR TITLE
Fix README.md mention of golang-migrate/migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terraform provider for managing SQL schemas using migrations.
 
-This plugin uses [golang-migrate/migrate](https://github.com/golang-migrate/migrate),
+This plugin uses [rubenv/sql-migrate](https://github.com/rubenv/sql-migrate),
 it is recommended to go read how it works before using this provider.
 
 ## Usage


### PR DESCRIPTION
The project uses rubenv/sql-migrate, not golang-migrate/migrate